### PR TITLE
docs: rename corp name to NHN Cloud

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2017 NHN Corp.
+Copyright (c) 2017 NHN Cloud Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ If you want to distinguish with `tui/es6`, use a version before 5.0.0
 [Configuring ESLint](http://eslint.org/docs/user-guide/configuring)
 
 ## License
-This software is licensed under the [MIT License](https://github.com/nhn/tui.eslint.config/blob/master/LICENSE).
+This software is licensed under the [MIT](https://github.com/nhn/tui.eslint.config/blob/master/LICENSE) © [NHN Cloud](https://github.com/nhn).

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "eslint-config",
     "eslint.config",
     "nhn",
+    "nhn cloud",
     "tui",
     "tui.eslint.config",
     "tui.eslint"
   ],
-  "author": "NHN. FE Development Lab <dl_javascript@nhn.com>",
+  "author": "NHN Cloud. FE Development Lab <dl_javascript@nhn.com>",
   "license": "MIT"
 }


### PR DESCRIPTION
* Rename the corporation name to "NHN Cloud"