### PR TITLE
feat: updated rule for 8.37.0~8.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-config-tui",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "ESLint sharable config for TUI components",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "eslint": "^8.36.0"
+    "eslint": "^8.49.0"
   },
   "repository": {
     "type": "git",

--- a/rules/suggestion.js
+++ b/rules/suggestion.js
@@ -84,7 +84,6 @@ module.exports = {
     "no-restricted-properties": 0,
     "no-restricted-syntax": [2, "WithStatement"],
     "no-return-assign": [2, "always"],
-    "no-return-await": 2,
     "no-script-url": 2,
     "no-sequences": [2, { allowInParentheses: false }],
     "no-shadow": [2, { ignoreOnInitialization: false }],


### PR DESCRIPTION
# 9월 16일 논의 결과

## no-return-await 규칙
*제거
  * v8.46.0에서 deprecated

## semi, no-irregular-whitespace, no-extra-parens, no-promise-executor-return, lines-between-class-members
* 옵션이 추가되었지만 이를 적용하지 않기로 결정(현상 유지)