### PR TITLE
chore: bump patch version for official deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tui",
-  "version": "6.0.1-beta",
+  "version": "6.0.1",
   "description": "ESLint sharable config for TUI components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 업무 내용

`v6.0.1-beta`([#25](https://github.com/nhn/tui.eslint.config/pull/25))가 올바르게 동작하는 것을 확인하였으므로 이를 `v6.0.1`로 배포합니다.
