### PR TITLE
feat: added rule for 9.31.0-9.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-config-tui",
-  "version": "6.30.1",
+  "version": "6.34.0",
   "description": "ESLint sharable config for TUI components",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "eslint": "^9.30.1",
+    "eslint": "^9.34.0",
     "globals": "^15.13.0"
   },
   "repository": {

--- a/rules/suggestion.js
+++ b/rules/suggestion.js
@@ -6,6 +6,7 @@ module.exports = {
         setWithoutGet: true,
         getWithoutSet: false,
         enforceForClassMembers: false,
+        enforceForTSTypes: true,
       },
     ],
     "arrow-body-style": [
@@ -32,7 +33,7 @@ module.exports = {
     ],
     "func-names": 0,
     "func-style": 0,
-    "grouped-accessor-pairs": [2, "getBeforeSet"],
+    "grouped-accessor-pairs": [2, "getBeforeSet", { enforceForTSTypes: true }],
     "guard-for-in": 2,
     "id-length": 0,
     "id-match": 0,
@@ -97,7 +98,10 @@ module.exports = {
     "no-proto": 2,
     "no-redeclare": 2,
     "no-regex-spaces": 2,
-    "no-restricted-globals": [1, "event", "fdescribe", "fit"],
+    "no-restricted-globals": [
+      1,
+      { globals: ["event"], checkGlobalObject: true },
+    ],
     "no-restricted-properties": 0,
     "no-restricted-syntax": [2, "WithStatement"],
     "no-return-assign": [2, "always"],


### PR DESCRIPTION
## 10월 23일 규칙 논의 결과

### 새로운 옵션

#### [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars): `ignoreUsingDeclarations` ([9.32.0](https://github.com/eslint/eslint/releases/tag/v9.32.0))
- 기존 `"error"` 유지
- `ignoreUsingDeclarations: false` 유지

#### [`one-var`](https://eslint.org/docs/latest/rules/one-var): `using`, `awaitUsing` ([9.33.0](https://github.com/eslint/eslint/releases/tag/v9.33.0))
- 기존 `"off"` 유지

#### [`no-restricted-globals`](https://eslint.org/docs/latest/rules/no-restricted-globals): `globals`, `checkGlobalObject`, `globalObjects` ([9.33.0](https://github.com/eslint/eslint/releases/tag/v9.33.0))
- 기존 `"warn"` 유지
- `event`만 제한하도록 변경
- `checkGlobalObject: true` 설정
- `fdescribe`, `fit` 제거

#### [`accessor-pairs`](https://eslint.org/docs/latest/rules/accessor-pairs), [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs): `enforceForTSTypes` ([9.32.0](https://github.com/eslint/eslint/releases/tag/v9.32.0))
- 기존 `"error"` 유지
- `enforceForTSTypes: true` 설정

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated ESLint configuration updates; main risk is new lint warnings/errors in consuming projects due to tightened TypeScript accessor checks and changed `no-restricted-globals` behavior.
> 
> **Overview**
> Updates `eslint-config-tui` to align with ESLint `9.34.0` by bumping the package version and `eslint` peer dependency.
> 
> Adjusts suggestion rules to adopt newer ESLint options: enables `enforceForTSTypes` for `accessor-pairs`/`grouped-accessor-pairs`, and refines `no-restricted-globals` to warn only on `event` (including `globalThis.event`) while removing restrictions on `fdescribe`/`fit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8780ffbf969fa91ef858413503e57ceab6dcd2a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->