### PR TITLE
feat: added rule for 9.35.0-9.39.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-config-tui",
-  "version": "6.34.0",
+  "version": "6.39.3",
   "description": "ESLint sharable config for TUI components",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "eslint": "^9.34.0",
+    "eslint": "^9.39.3",
     "globals": "^15.13.0"
   },
   "repository": {

--- a/rules/suggestion.js
+++ b/rules/suggestion.js
@@ -160,6 +160,7 @@ module.exports = {
     "prefer-rest-params": 2,
     "prefer-spread": 2,
     "prefer-template": 2,
+    "preserve-caught-error": 2,
     "quote-props": 0,
     radix: 2,
     "require-await": 2,


### PR DESCRIPTION
## 3월 10일 규칙 논의 결과

### 새로운 규칙

#### [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) ([9.35.0](https://github.com/eslint/eslint/releases/tag/v9.35.0))
- 신규 규칙 추가
- `"error"` 설정

### 새로운 옵션

#### [`no-restricted-imports`](https://eslint.org/docs/latest/rules/no-restricted-imports): `allowTypeImports` ([9.37.0](https://github.com/eslint/eslint/releases/tag/v9.37.0))
- 기존 `"off"` 유지

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: updates package/peer versions and enables a new ESLint rule, which may introduce new lint failures but does not affect runtime behavior.
> 
> **Overview**
> Updates `eslint-config-tui` to version `6.39.3` and bumps the `eslint` peer dependency to `^9.39.3`.
> 
> Enables ESLint’s new `preserve-caught-error` rule at `error` level in `rules/suggestion.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a329ccca9d907ad06e0f9be4a38b66ed99b46c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->